### PR TITLE
feat: add axios instance and add sign up page

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^2.8.8",
+    "axios": "^0.26.0",
     "next": "12.1.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",
@@ -25,6 +26,7 @@
     "@svgr/webpack": "^6.2.1",
     "@types/node": "17.0.21",
     "@types/react": "17.0.39",
+    "@types/yup": "^0.29.13",
     "@typescript-eslint/eslint-plugin": "^5.12.1",
     "@typescript-eslint/parser": "^5.12.1",
     "eslint": "<8.0.0",

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,8 +1,11 @@
 import { ReactChild, ReactChildren } from 'react';
 
+import Header from './molecules/header';
+
 export default function Layout({ children }: { children: ReactChild | ReactChildren }) {
   return (
     <>
+      <Header />
       <div className="children">{children}</div>
       <style jsx>
         {`

--- a/src/components/molecules/header/index.tsx
+++ b/src/components/molecules/header/index.tsx
@@ -1,0 +1,22 @@
+import { useRouter } from 'next/router';
+
+import { Container, TitleWrapper, Title, SubTitle, HeaderBtn } from './styles';
+
+const Header = () => {
+  const router = useRouter();
+
+  return (
+    <Container>
+      <TitleWrapper>
+        <Title onClick={() => router.push('/')}>Cola</Title>
+        <SubTitle>아주대학교 개발자 커뮤니티</SubTitle>
+      </TitleWrapper>
+      {router.route !== '/login' && (
+        <HeaderBtn type="button" onClick={() => router.push('/login')}>
+          로그인
+        </HeaderBtn>
+      )}
+    </Container>
+  );
+};
+export default Header;

--- a/src/components/molecules/header/styles.tsx
+++ b/src/components/molecules/header/styles.tsx
@@ -1,0 +1,35 @@
+import styled from '@emotion/styled';
+
+const Container = styled.div`
+  width: 100vw;
+  height: 80px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: #151d3b;
+  color: whitesmoke;
+`;
+const TitleWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+const Title = styled.span`
+  font-size: 36px;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0px 10px;
+`;
+const SubTitle = styled.span`
+  font-size: 14px;
+  padding: 0px 10px;
+`;
+const HeaderBtn = styled.button`
+  background: none;
+  border: none;
+  padding: 5px 10px;
+  font-size: 14px;
+  color: whitesmoke;
+  cursor: pointer;
+`;
+
+export { Container, TitleWrapper, Title, SubTitle, HeaderBtn };

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -1,11 +1,10 @@
-import { useState, useEffect } from 'react';
-
 import { yupResolver } from '@hookform/resolvers/yup';
+import { useRouter } from 'next/router';
 import { useForm, SubmitHandler } from 'react-hook-form';
 import * as yup from 'yup';
 
 import { LoginFormInterface } from './index.type';
-import { Container, Header, FormWrapper } from './styles';
+import { Container, Header, FormWrapper, AuthContentWrapper, SocialLogin, RouterText } from './styles';
 
 import Seo from '@components/Seo';
 
@@ -17,6 +16,7 @@ const schema = yup
   .required();
 
 const Login = () => {
+  const router = useRouter();
   const {
     register,
     handleSubmit,
@@ -46,7 +46,22 @@ const Login = () => {
         </div>
         <button>로그인</button>
       </FormWrapper>
-      {/* <div>소셜로그인자리</div> */}
+      <AuthContentWrapper>
+        <RouterText
+          onClick={() => {
+            router.push('/signup');
+          }}
+        >
+          회원가입
+        </RouterText>
+        <SocialLogin>
+          <p>소셜 로그인</p>
+          <ul>
+            <li>깃허브</li>
+            <li>깃랩</li>
+          </ul>
+        </SocialLogin>
+      </AuthContentWrapper>
     </Container>
   );
 };

--- a/src/pages/login/styles.ts
+++ b/src/pages/login/styles.ts
@@ -3,12 +3,12 @@ import styled from '@emotion/styled';
 const Container = styled.div`
   text-align: -webkit-center;
   width: 100vw;
-  height: 100vh;
+  height: calc(100vh - 70px);
   display: grid;
   grid-template:
     '. Title .' 1fr
     '. Form .' 1fr
-    '. . .' 6fr
+    '. Auth .' 6fr
     /2fr 1fr 2fr;
 
   /* display: flex;
@@ -37,17 +37,17 @@ const FormWrapper = styled.form`
   button {
     /* width: 10vw; */
     padding: 10px 5vh;
-    background: #2d31fa;
+    background: #151d3b;
     color: white;
     border: none;
     border-radius: 20px;
-    transition: 0.4s;
+    transition: 0.2s ease-in-out;
     &:hover {
       cursor: pointer;
-      background-color: #5d8bf4;
+      background-color: #084594;
     }
     &:active {
-      background-color: #2d31fa;
+      background-color: #151d3b;
     }
   }
   input {
@@ -56,5 +56,35 @@ const FormWrapper = styled.form`
     padding: 5px;
   }
 `;
+const AuthContentWrapper = styled.div`
+  grid-area: Auth;
+  width: 300px;
+  padding: 10px 0;
 
-export { Container, Header, FormWrapper };
+  p {
+    color: #222;
+    font-size: 14px;
+  }
+`;
+
+const SocialLogin = styled.div`
+  width: 100%;
+  p {
+    font-size: 16px;
+    font-weight: 600;
+  }
+  ul {
+    display: flex;
+    justify-content: space-evenly;
+    list-style: none;
+    padding: 0;
+    li {
+      cursor: pointer;
+    }
+  }
+`;
+
+const RouterText = styled.span`
+  cursor: pointer;
+`;
+export { Container, Header, FormWrapper, AuthContentWrapper, SocialLogin, RouterText };

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -1,0 +1,127 @@
+import { useForm } from 'react-hook-form';
+
+import { SignupFormInterface } from './index.type';
+import { Container, Title, SubTitle, FormWrapper, SubFormWrapper, EmailAuthBtn, SubmitBtn } from './styles';
+
+const SignUp = () => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    setError,
+  } = useForm<SignupFormInterface>({
+    mode: 'onBlur',
+    defaultValues: {
+      email: '@ajou.ac.kr',
+    },
+  });
+
+  const onSubmit = (data: SignupFormInterface) => {
+    console.log(data);
+  };
+  console.log(errors);
+
+  return (
+    <Container>
+      <Title>회원가입</Title>
+      <FormWrapper onSubmit={handleSubmit(onSubmit)}>
+        <SubFormWrapper>
+          <SubTitle>아이디/비밀번호</SubTitle>
+          <div>
+            <input
+              type="text"
+              placeholder="아이디"
+              {...register('id', {
+                required: '아이디를 입력해주세요.',
+              })}
+            />
+            {errors?.id?.message}
+          </div>
+          <div>
+            <input
+              type="password"
+              placeholder="비밀번호"
+              {...register('password', {
+                required: '비밀번호를 입력해주세요.',
+                // TODO: 비밀번호 형식 pattern
+              })}
+            />
+            {errors?.password?.message}
+          </div>
+          <div>
+            <input
+              type="password"
+              placeholder="비밀번호 확인"
+              {...register('passwordCheck', {
+                required: '비밀번호를 다시 입력해주세요.',
+                // TODO: 비밀번호 형식 pattern, password와 같은지 검증
+              })}
+            />
+            {errors?.passwordCheck?.message}
+          </div>
+        </SubFormWrapper>
+        <SubFormWrapper>
+          <SubTitle>아주대 메일 인증</SubTitle>
+          <div>
+            <input
+              type="text"
+              placeholder="아주대 메일"
+              {...register('email', {
+                required: '아주대 이메일을 입력해주세요.',
+                pattern: {
+                  value: /^[A-Za-z0-9._%+-]+@ajou.ac.kr$/,
+                  message: '아주대 이메일만 사용할 수 있습니다.',
+                },
+              })}
+            />
+            {errors?.email?.message}
+          </div>
+
+          <EmailAuthBtn type="button">인증</EmailAuthBtn>
+        </SubFormWrapper>
+        <SubFormWrapper>
+          <SubTitle>학생 정보</SubTitle>
+          <div>
+            <input
+              type="text"
+              placeholder="이름"
+              {...register('name', {
+                required: '이름을 입력해주세요',
+              })}
+            />
+            {errors?.name?.message}
+          </div>
+
+          <div>
+            <input
+              type="text"
+              placeholder="학과"
+              {...register('department', {
+                required: '학과를 입력해주세요',
+              })}
+            />
+            {errors?.department?.message}
+          </div>
+
+          <div>
+            <input
+              type="text"
+              placeholder="학번"
+              {...register('studentId', {
+                required: '학번을 입력해주세요',
+                pattern: {
+                  value: /^[0-9]{9}$/,
+                  message: '학번을 제대로 입력해주세요.',
+                },
+              })}
+            />
+            {errors?.studentId?.message}
+          </div>
+        </SubFormWrapper>
+
+        <SubmitBtn>회원가입</SubmitBtn>
+      </FormWrapper>
+    </Container>
+  );
+};
+export default SignUp;

--- a/src/pages/signup/index.type.ts
+++ b/src/pages/signup/index.type.ts
@@ -1,0 +1,9 @@
+export interface SignupFormInterface {
+  id: string;
+  password: string;
+  passwordCheck: string;
+  email: string;
+  name: string;
+  department: string;
+  studentId: string;
+}

--- a/src/pages/signup/styles.ts
+++ b/src/pages/signup/styles.ts
@@ -1,0 +1,11 @@
+import styled from '@emotion/styled';
+
+const Container = styled.div``;
+const Title = styled.h1``;
+const SubTitle = styled.h3``;
+const FormWrapper = styled.form``;
+const SubFormWrapper = styled.div``;
+const EmailAuthBtn = styled.button``;
+const SubmitBtn = styled.button``;
+
+export { Container, Title, SubTitle, FormWrapper, SubFormWrapper, EmailAuthBtn, SubmitBtn };

--- a/src/utils/api/core/index.ts
+++ b/src/utils/api/core/index.ts
@@ -1,0 +1,27 @@
+import axios from 'axios';
+
+const Api = axios.create({
+  baseURL: process.env.API_BASE_URL || '',
+});
+Api.defaults.timeout = 2500;
+Api.interceptors.request.use(
+  (config) => {
+    return config;
+  },
+  (error) => {
+    console.log(error);
+    return Promise.reject(error);
+  },
+);
+Api.interceptors.response.use(
+  (response) => {
+    const res = response.data;
+    return res;
+  },
+  (error) => {
+    console.log(error);
+    return Promise.reject(error);
+  },
+);
+
+export default Api;

--- a/src/utils/api/main.ts
+++ b/src/utils/api/main.ts
@@ -1,0 +1,10 @@
+import axios from './core/index';
+// api 목록
+
+// const singIn = (id, password) => {
+//   return axios.post('/signin');
+// };
+
+export default {
+  // singIn,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1014,7 +1014,7 @@
 
 "@emotion/cache@^11.7.1":
   version "11.7.1"
-  resolved "https://registry.npmjs.org/@emotion/cache/-/cache-11.7.1.tgz"
+  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.7.1.tgz#08d080e396a42e0037848214e8aa7bf879065539"
   integrity sha512-r65Zy4Iljb8oyjtLeCuBH8Qjiy107dOYC6SJq7g7GV5UCQWMObY4SJDPGFjiiVpPrOJ2hmJOoBiYTC7hwx9E2A==
   dependencies:
     "@emotion/memoize" "^0.7.4"
@@ -1042,7 +1042,7 @@
 
 "@emotion/react@^11.8.1":
   version "11.8.1"
-  resolved "https://registry.npmjs.org/@emotion/react/-/react-11.8.1.tgz"
+  resolved "https://registry.yarnpkg.com/@emotion/react/-/react-11.8.1.tgz#5358b8c78367063881e26423057c030c57ce52eb"
   integrity sha512-XGaie4nRxmtP1BZYBXqC5JGqMYF2KRKKI7vjqNvQxyRpekVAZhb6QqrElmZCAYXH1L90lAelADSVZC4PFsrJ8Q==
   dependencies:
     "@babel/runtime" "^7.13.10"
@@ -1067,7 +1067,7 @@
 
 "@emotion/sheet@^1.1.0":
   version "1.1.0"
-  resolved "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.1.0.tgz"
+  resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.1.0.tgz#56d99c41f0a1cda2726a05aa6a20afd4c63e58d2"
   integrity sha512-u0AX4aSo25sMAygCuQTzS+HsImZFuS8llY8O7b9MDRzbJM0kVJlAz6KNDqcG7pOuQZJmj/8X/rAW+66kMnMW+g==
 
 "@emotion/styled@^11.8.1":
@@ -1093,7 +1093,7 @@
 
 "@emotion/weak-memoize@^0.2.5":
   version "0.2.5"
-  resolved "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz"
+  resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
 "@eslint/eslintrc@^0.4.3":
@@ -1394,6 +1394,11 @@
   resolved "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz"
   integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
 
+"@types/yup@^0.29.13":
+  version "0.29.13"
+  resolved "https://registry.yarnpkg.com/@types/yup/-/yup-0.29.13.tgz#21b137ba60841307a3c8a1050d3bf4e63ad561e9"
+  integrity sha512-qRyuv+P/1t1JK1rA+elmK1MmCL1BapEzKKfbEhDBV/LMMse4lmhZ/XbgETI39JveDJRpLjmToOI6uFtMW/WR2g==
+
 "@typescript-eslint/eslint-plugin@^5.12.1":
   version "5.12.1"
   resolved "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.12.1.tgz"
@@ -1591,6 +1596,13 @@ axe-core@^4.3.5:
   version "4.4.1"
   resolved "https://registry.npmjs.org/axe-core/-/axe-core-4.4.1.tgz"
   integrity sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw==
+
+axios@^0.26.0:
+  version "0.26.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.26.0.tgz#9a318f1c69ec108f8cd5f3c3d390366635e13928"
+  integrity sha512-lKoGLMYtHvFrPVt3r+RBMp9nh34N0M8zEfCWqdWZx6phynIEhQqAdydpyBAAG211zlhX9Rgu08cOamy6XjE5Og==
+  dependencies:
+    follow-redirects "^1.14.8"
 
 axobject-query@^2.2.0:
   version "2.2.0"
@@ -2390,6 +2402,11 @@ flatted@^3.1.0:
   resolved "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz"
   integrity sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==
 
+follow-redirects@^1.14.8:
+  version "1.14.9"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.9.tgz#dd4ea157de7bfaf9ea9b3fbd85aa16951f78d8d7"
+  integrity sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
@@ -2523,7 +2540,7 @@ has@^1.0.3:
 
 hoist-non-react-statics@^3.3.1:
   version "3.3.2"
-  resolved "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
   dependencies:
     react-is "^16.7.0"


### PR DESCRIPTION
### 🔨 작업 내용
- axios 디펜던시 추가 및 axios instance 생성
  - utils/api에 생성
- yup 라이브러리의 타입 지원을 위한 @types/yup 디펜던시 추가
### 📐 구현한 내용
- Header 컴포넌트 추가
  - 모든 페이지에서 상단에 나타날 수 있도록 Layout 컴포넌트에 추가하였습니다.
- 회원가입 페이지 추가
  - 로그인 페이지의 로그인 버튼 하단에 회원가입 버튼을 추가하여 페이지를 이동할 수 있도록 하였습니다.
  - react-hook-form 을 이용하여 기본적인 form 형태를 만들었습니다. 

### 🚧 논의 사항
 - 추후 react-query를 이용한 api들을 utils/api/main.ts에서 관리할 수 있도록 하면 좋을 것 같습니다.
 - 디자인 초안이 나오게 되면 여러 곳에서 사용가능한 공통 ui를 묶어서 재사용할 수 있도록 하면 좋을 것 같습니다.
 - 글로벌 스타일로 모든 스타일을 초기화 할 필요가 있을 것 같습니다.
     -  li 태그 등의 기본 스타일 제거
  
