### PR TITLE
[Fix] CheckboxWrapper 이름 변경

### DIFF
--- a/src/components/atoms/checkbox/index.tsx
+++ b/src/components/atoms/checkbox/index.tsx
@@ -1,6 +1,6 @@
 import { Dispatch, SetStateAction } from 'react';
 
-import { CheckboxWarpper, Checkbox, CustomCheckbox, CheckboxLabel } from './styles';
+import { CheckboxWrapper, Checkbox, CustomCheckbox, CheckboxLabel } from './styles';
 
 interface ICheckbox {
   checked: boolean;
@@ -12,7 +12,7 @@ interface ICheckbox {
 
 const CheckboxInput = ({ checked, setCheck, checkboxName, checkboxId, checkboxLabel }: ICheckbox) => {
   return (
-    <CheckboxWarpper>
+    <CheckboxWrapper>
       <Checkbox
         type={'checkbox'}
         checked={checked}
@@ -22,7 +22,7 @@ const CheckboxInput = ({ checked, setCheck, checkboxName, checkboxId, checkboxLa
       />
       <CustomCheckbox htmlFor={checkboxId} id={`custom-${checkboxId}`} />
       <CheckboxLabel htmlFor={checkboxId}>{checkboxLabel}</CheckboxLabel>
-    </CheckboxWarpper>
+    </CheckboxWrapper>
   );
 };
 export default CheckboxInput;

--- a/src/components/atoms/checkbox/styles.ts
+++ b/src/components/atoms/checkbox/styles.ts
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-const CheckboxWarpper = styled.div`
+const CheckboxWrapper = styled.div`
   display: flex;
   gap: 10px;
   align-items: center;
@@ -41,4 +41,4 @@ const CheckboxLabel = styled.label`
   cursor: pointer;
 `;
 
-export { CheckboxWarpper, Checkbox, CustomCheckbox, CheckboxLabel };
+export { CheckboxWrapper, Checkbox, CustomCheckbox, CheckboxLabel };


### PR DESCRIPTION
### 🔨 작업 내용
- CheckboxWrapper 이름 변경
### 📐 구현한 내용
- 본 Object의 사용과 목적에 따라 "Warpper"가 아니라 "Wrapper"가 올바른 표기입니다. 🙌
### 🚧 논의 사항
- 없음
